### PR TITLE
add -v flag to hexdump command not to replace repetitive lines by an asterisk

### DIFF
--- a/snap-guest
+++ b/snap-guest
@@ -191,7 +191,7 @@ done
 SOURCE_IMG=$(ls -v1 $BASE_IMAGE_DIR/${SOURCE_NAME}*.img | tail -n1)
 TARGET_IMG=$IMAGE_DIR/$TARGET_NAME.img
 TARGET_IMG_SWAP=$IMAGE_DIR/$TARGET_NAME-swap.img
-MAC="52:54:00$(echo "$(hostname)$TARGET_NAME" | openssl dgst -md5 -binary | hexdump -e '/1 ":%02x"' -n 3)"
+MAC="52:54:00$(echo "$(hostname)$TARGET_NAME" | openssl dgst -md5 -binary | hexdump -ve '/1 ":%02x"' -n 3)"
 TARGET_HOSTNAME=$TARGET_HOSTNAME
 if [ -z "$TARGET_HOSTNAME" ]; then
   TARGET_HOSTNAME="$PREFIX$TARGET_NAME$DOMAIN"


### PR DESCRIPTION
the default behaviour of `hexdump` is to squeeze the repeating lines by replacing them by a `*` our MAC addr generating mechanism accepted this and occasionally returned invalid MAC containing the asterisk and a newline, causing the whole virt-install command to fail.

This commit remedies that:
```
-v, --no-squeezing
   The  -v  option  causes  hexdump  to display all input data.  Without the -v option, any number of groups of output lines which would be identical to the
   immediately preceding group of output lines (except for the input offsets), are replaced with a line comprised of a single asterisk.
```