### PR TITLE
Make adding hostname bound to IP 127.0.0.1 as opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Here you can find all parameters:
             Force creating new guest (no questions, destroys one the same name)
       --add-ip | -w
             Add IP address to /etc/hosts (works only with NAT)
+      --loopback-hostname
+            Add hostname assigned to 127.0.0.1 to /etc/hosts
       --graphics [opts] | -g [opts]
             Graphics options passed to virt-install via --graphics
             (default is vnc,listen=0.0.0.0)

--- a/prepare-image.pl
+++ b/prepare-image.pl
@@ -45,12 +45,14 @@ print "Configuring message of the day\n";
 $content = "\n\nSnap-guest box from $ENV{SOURCE_NAME} on " . `date` . "\n\n";
 $g->write ("/etc/motd", $content);
 
-print "Configuring /etc/hosts file\n";
-$file = "/etc/hosts";
-$content = $g->read_file ($file);
-$content =~ s/$ENV{SOURCE_NAME}/localbox/g;
-$content .= "\n127.0.0.1 $ENV{TARGET_HOSTNAME} $ENV{TARGET_NAME}\n";
-$g->write ($file, $content);
+if ($ENV{LOOPBACK_HOSTNAME} == 1) {
+  print "Configuring /etc/hosts file\n";
+  $file = "/etc/hosts";
+  $content = $g->read_file ($file);
+  $content =~ s/$ENV{SOURCE_NAME}/localbox/g;
+  $content .= "\n127.0.0.1 $ENV{TARGET_HOSTNAME} $ENV{TARGET_NAME}\n";
+  $g->write ($file, $content);
+}
 
 if ($distro eq "debian" || $distro eq "ubuntu") {
   print "Setting up for Debian\n";

--- a/snap-guest
+++ b/snap-guest
@@ -40,6 +40,8 @@ OPTIONS:
         Force creating new guest (destroy existing, no questions, DANGEROUS!)
   --add-ip | -w
         Add IP address to /etc/hosts on the host machine (works only with NAT)
+  --loopback-hostname
+        Add hostname assigned to 127.0.0.1 to /etc/hosts
   --graphics [opts] | -g [opts]
         Graphics options passed to virt-install via --graphics
         (default is vnc,listen=0.0.0.0)
@@ -126,8 +128,9 @@ STATIC_IPADDR=""
 STATIC_NETMASK=""
 STATIC_GATEWAY=""
 CPU_FEATURE=""
+LOOPBACK_HOSTNAME=0
 
-if ! options=$(getopt -o hlfwb:t:n:m:c:d:p:s:1:g:i: -l list,list-all,force,add-ip,image-dir:,base-image-dir:,base:,graphics:,target:,hostname:,network:,network2:,memory:,cpus:,domain:,domain-prefix:,swap:,firstboot:,cloud-image,cloud-preconf,user-data-ssh,user-data-stdin,user-data-file:,boot-script,boot-script-prefix:,static-ipaddr:,static-netmask:,static-gateway:,cpu-feature:,help -- "$@"); then
+if ! options=$(getopt -o hlfwb:t:n:m:c:d:p:s:1:g:i: -l list,list-all,force,add-ip,image-dir:,base-image-dir:,base:,graphics:,target:,hostname:,network:,network2:,memory:,cpus:,domain:,domain-prefix:,swap:,firstboot:,cloud-image,cloud-preconf,user-data-ssh,user-data-stdin,user-data-file:,boot-script,boot-script-prefix:,static-ipaddr:,static-netmask:,static-gateway:,cpu-feature:,loopback-hostname,help -- "$@"); then
   exit 1
 fi
 
@@ -164,6 +167,7 @@ while [ $# -gt 0 ]; do
     --static-netmask) STATIC_NETMASK="$2" ; shift ;;
     --static-gateway) STATIC_GATEWAY="$2" ; shift ;;
     --cpu-feature) CPU_FEATURE="--cpu=$2" ; shift ;;
+    --loopback-hostname) LOOPBACK_HOSTNAME=1 ;;
     --help|-h) usage;  exit ;;
     (--) shift; break;;
     (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
@@ -227,7 +231,7 @@ qemu-img create -f qcow2 -b $SOURCE_IMG $TARGET_IMG
 
 if [ $CLOUD -eq 0 -o $CLOUD_PRECONF -eq 1 ]; then
   export COMMAND TARGET_HOSTNAME MAC SOURCE_NAME SWAP TARGET_IMG TARGET_NAME \
-    STATIC_IPADDR STATIC_NETMASK STATIC_GATEWAY
+    STATIC_IPADDR STATIC_NETMASK STATIC_GATEWAY LOOPBACK_HOSTNAME
   perl -w "$SCRIPTDIR/prepare-image.pl"
 fi
 


### PR DESCRIPTION
Make adding hostname bound to IP 127.0.0.1 as opt-in
- since this causing breakages "Reverse DNS localhost does not match hostname sat.example.com"
- fix_hostname is also broken it just duplicates the record with 127.0.0.1

Instead of removing the code I changed it as an opt-in by passing new option ```--loopback-hostname```