### PR TITLE
Fix virt-install error when guestfs domain is being shut down yet

### DIFF
--- a/snap-guest
+++ b/snap-guest
@@ -292,7 +292,7 @@ echo "CPUs:     $CPUS"
 echo "Memory:   $MEM MB"
 echo "Swap:     $MEM MB"
 echo "MAC:      $MAC"
-virt-install --vcpus $CPUS \
+while ! virt-install --vcpus $CPUS \
   --ram $MEM --import \
   --name $TARGET_NAME \
   --disk $TARGET_IMG,device=disk,bus=virtio,format=qcow2 $DISK_SWAP $DISK_SEED \
@@ -301,6 +301,7 @@ virt-install --vcpus $CPUS \
   --network=$NETWORK,mac=$MAC \
   $NETWORK2 \
   $CPU_FEATURE
+do sleep 1; done
 
 # -- IP Determining -------------
 # TODO: Use this instead: http://rwmj.wordpress.com/2010/10/26/tip-find-the-ip-address-of-a-virtual-machine/


### PR DESCRIPTION
This PR turns snap-guest into much more stable tool providing VMs even under heavy workload. 
Mitigating this error:
```ERROR    Error: --network bridge=br0,mac=52:54:00:33:20:22: Domain not found: no domain with matching uuid 'b43d9f70-4954-4538-85c5-7d196c7ff3dd' (guestfs-zb55tn9du4y8dk7b)```

Fixes #5