### PR TITLE
Recover also from pool race condition

### DIFF
--- a/snap-guest
+++ b/snap-guest
@@ -302,8 +302,8 @@ while virt-install --vcpus $CPUS \
   --network=$NETWORK,mac=$MAC \
   $NETWORK2 \
   $CPU_FEATURE 2> >(tee $STDERR)
-  # loop only if stderr contains the race condition error
-  grep -q "Domain not found:" $STDERR
+  # loop only if stderr contains the race condition errors
+  grep -qE "Domain not found:|already in use by another pool" $STDERR
 do sleep 1; done
 
 # -- IP Determining -------------


### PR DESCRIPTION
When snap-guest uses non-default storage pool `-p /opt/robottelo/disks` on some machines with new fedora it fails with:
```
ERROR    Error: --disk /opt/robottelo/images/machine.example.com.img,device=disk,bus=virtio,format=qcow2: Name 'images' already in use by another pool.
```
So we need to handle also this race condition and recover from it by simply re-trying.