### PR TITLE
Add support for qemu-guest-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Here you can find all parameters:
       --firstboot [command] | -1 [command]
             Command to execute during first boot in /root dir
             (logfile available in /root/firstboot.log)
+      --qemu-ga
+            Add qemu-ga channel device to support qemu-guest-agent
       --cloud-image
             Disables image manipulation and enables cloud-init seed via CD-ROM
       --user-data-file [file]

--- a/snap-guest
+++ b/snap-guest
@@ -53,6 +53,8 @@ OPTIONS:
   --firstboot [command] | -1 [command]
         Command to execute during first boot in /root dir
         (logfile available in /root/firstboot.log)
+  --qemu-ga
+        Add qemu-ga channel device to support qemu-guest-agent
   --cloud-image
         Disables image manipulation and enables cloud-init seed via CD-ROM
   --cloud-preconf
@@ -129,8 +131,9 @@ STATIC_NETMASK=""
 STATIC_GATEWAY=""
 CPU_FEATURE=""
 LOOPBACK_HOSTNAME=0
+QEMU_GA=0
 
-if ! options=$(getopt -o hlfwb:t:n:m:c:d:p:s:1:g:i: -l list,list-all,force,add-ip,image-dir:,base-image-dir:,base:,graphics:,target:,hostname:,network:,network2:,memory:,cpus:,domain:,domain-prefix:,swap:,firstboot:,cloud-image,cloud-preconf,user-data-ssh,user-data-stdin,user-data-file:,boot-script,boot-script-prefix:,static-ipaddr:,static-netmask:,static-gateway:,cpu-feature:,loopback-hostname,help -- "$@"); then
+if ! options=$(getopt -o hlfwb:t:n:m:c:d:p:s:1:g:i: -l list,list-all,force,add-ip,image-dir:,base-image-dir:,base:,graphics:,target:,hostname:,network:,network2:,memory:,cpus:,domain:,domain-prefix:,swap:,firstboot:,cloud-image,cloud-preconf,user-data-ssh,user-data-stdin,user-data-file:,boot-script,boot-script-prefix:,static-ipaddr:,static-netmask:,static-gateway:,cpu-feature:,loopback-hostname,qemu-ga,help -- "$@"); then
   exit 1
 fi
 
@@ -168,6 +171,7 @@ while [ $# -gt 0 ]; do
     --static-gateway) STATIC_GATEWAY="$2" ; shift ;;
     --cpu-feature) CPU_FEATURE="--cpu=$2" ; shift ;;
     --loopback-hostname) LOOPBACK_HOSTNAME=1 ;;
+    --qemu-ga) QEMU_GA=1 ;;
     --help|-h) usage;  exit ;;
     (--) shift; break;;
     (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
@@ -284,6 +288,12 @@ else
   DISK_SWAP=""
 fi
 
+# -- Qemu guest agent support 
+
+if [ $QEMU_GA -eq 1 ]; then
+  QEMU_GA_DEVICE="--channel unix,path=/var/lib/libvirt/qemu/$TARGET_NAME.agent,mode=bind,target_type=virtio,name=org.qemu.guest_agent.0"
+fi
+
 # -- Image Provisioning ---------
 
 echo "Provisioning guest $TARGET_NAME"
@@ -301,6 +311,7 @@ while virt-install --vcpus $CPUS \
   --noautoconsole --force \
   --network=$NETWORK,mac=$MAC \
   $NETWORK2 \
+  $QEMU_GA_DEVICE \
   $CPU_FEATURE 2> >(tee $STDERR)
   # loop only if stderr contains the race condition errors
   grep -qE "Domain not found:|already in use by another pool" $STDERR


### PR DESCRIPTION
This PR adds option for future possible switch from avahi-discovery to qemu-guest-agent for guests IP discovery.

If a VM has special channel device `qemu-ga` present and `qemu-guest-agent` installed then we can easily find its IP address @hypervisor by running:
```
virsh qemu-agent-command $VM '{"execute":"guest-network-get-interfaces"}'
```
No need to install anything on hypervisors/satellites