### PR TITLE
RHEL8 NIC support

### DIFF
--- a/prepare-image.pl
+++ b/prepare-image.pl
@@ -61,6 +61,7 @@ if ($distro eq "debian" || $distro eq "ubuntu") {
 elsif ($distro =~ m/^(fedora|rhel|redhat-based|centos|scientificlinux)$/) {
   print "Setting up for Fedora / RHEL\n";
   $file = "/etc/sysconfig/network-scripts/ifcfg-eth0";
+  $file =  $g->exists ($file) ? $file : "/etc/sysconfig/network-scripts/ifcfg-ens3";
   if ($ENV{STATIC_IPADDR}) {
     print "Setting static network configuration\n";
     $content = "DEVICE=eth0\n";


### PR DESCRIPTION
This PR solves networking issue for RHEL8 - use ```ifcfg-eth0``` if present otherwise switch to using ```ifcfg-ens3```

<br>RHEL6:<br> ifcfg-eth0 configures ```eth0```
<br>RHEL7:<br> ifcfg-eth0 still may configure ```ens3```
<br>RHEL8:<br> ifcfg-ens3 configures ```ens3```