### PR TITLE
Add new option '--clone-image' for independent image instead of snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Here you can find all parameters:
             Target images path (default: /var/lib/libvirt/images/)
       --base-image-dir [path]
             Base images path (default: /var/lib/libvirt/images/)
+      --clone-image
+            Clone target image as independent instead of creating CoW snapshot
       --domain [domain] | -d [domain]
             Domain suffix like "mycompany.com" (default: none)
       --domain-prefix [prefix]

--- a/snap-guest
+++ b/snap-guest
@@ -32,6 +32,8 @@ OPTIONS:
         Target images path (default: /var/lib/libvirt/images/)
   --base-image-dir [path]
         Base images path (default: /var/lib/libvirt/images/)
+  --clone-image
+        Clone target image as independent instead of creating CoW snapshot
   --domain [domain] | -d [domain]
         Domain suffix like "mycompany.com" (default: none)
   --domain-prefix [prefix]
@@ -132,8 +134,9 @@ STATIC_GATEWAY=""
 CPU_FEATURE=""
 LOOPBACK_HOSTNAME=0
 QEMU_GA=0
+CLONE_IMAGE=0
 
-if ! options=$(getopt -o hlfwb:t:n:m:c:d:p:s:1:g:i: -l list,list-all,force,add-ip,image-dir:,base-image-dir:,base:,graphics:,target:,hostname:,network:,network2:,memory:,cpus:,domain:,domain-prefix:,swap:,firstboot:,cloud-image,cloud-preconf,user-data-ssh,user-data-stdin,user-data-file:,boot-script,boot-script-prefix:,static-ipaddr:,static-netmask:,static-gateway:,cpu-feature:,loopback-hostname,qemu-ga,help -- "$@"); then
+if ! options=$(getopt -o hlfwb:t:n:m:c:d:p:s:1:g:i: -l list,list-all,force,add-ip,image-dir:,base-image-dir:,base:,graphics:,target:,hostname:,network:,network2:,memory:,cpus:,domain:,domain-prefix:,swap:,firstboot:,cloud-image,cloud-preconf,user-data-ssh,user-data-stdin,user-data-file:,boot-script,boot-script-prefix:,static-ipaddr:,static-netmask:,static-gateway:,cpu-feature:,loopback-hostname,qemu-ga,clone-image,help -- "$@"); then
   exit 1
 fi
 
@@ -172,6 +175,7 @@ while [ $# -gt 0 ]; do
     --cpu-feature) CPU_FEATURE="--cpu=$2" ; shift ;;
     --loopback-hostname) LOOPBACK_HOSTNAME=1 ;;
     --qemu-ga) QEMU_GA=1 ;;
+    --clone-image) CLONE_IMAGE=1 ;;
     --help|-h) usage;  exit ;;
     (--) shift; break;;
     (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
@@ -229,7 +233,11 @@ echo "Creating snapshot guest $TARGET_NAME"
 # -- Image Creation --------------
 
 echo "Creating snapshot image"
-qemu-img create -f qcow2 -b $SOURCE_IMG $TARGET_IMG
+if [ $CLONE_IMAGE -eq 1 ]; then
+  cp $SOURCE_IMG $TARGET_IMG
+else
+  qemu-img create -f qcow2 -b $SOURCE_IMG $TARGET_IMG
+fi
 
 # -- Image Manipulation ----------
 


### PR DESCRIPTION
```
  --clone-image
        Clone target image as independent instead of creating CoW snapshot
```
By using this new option you get independent image at the cost of small time penalty (max 10 secs)

This is useful for Satellite image since we get all Satellite instances independent of base image. Time penalty is not a problem here as we provision Satellite once an automation run. 

Independent Satellite instances means we can update base image any time even if Satellite instances are still running automation.