### PR TITLE
Migrate snap-guest to qcow2

### DIFF
--- a/snap-guest
+++ b/snap-guest
@@ -184,8 +184,8 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-[ $LIST -eq 1 ] && ls "$BASE_IMAGE_DIR" | grep '\.img' | grep base | sed 's/\.img//g' && exit 0
-[ $LIST_ALL -eq 1 ] && ls "$BASE_IMAGE_DIR" | grep '\.img' | sed 's/\.img//g' && exit 0
+[ $LIST -eq 1 ] && ls "$BASE_IMAGE_DIR" | grep -e '\.img' -e '\.qcow2' | grep base | sed -e 's/\.img//g' -e 's/\.qcow2//g' && exit 0
+[ $LIST_ALL -eq 1 ] && ls "$BASE_IMAGE_DIR" | grep -e '\.img' -e '\.qcow2' | sed -e 's/\.img//g' -e 's/\.qcow2//g' && exit 0
 
 if [ -z "$SOURCE_NAME" -o -z "$TARGET_NAME" ]; then
   usage; exit 1
@@ -200,18 +200,20 @@ for BINARY in getopt virsh qemu-img mkswap sed tail openssl hexdump perl genisoi
   fi
 done
 
-SOURCE_IMG=$(ls -v1 $BASE_IMAGE_DIR/${SOURCE_NAME}*.img | tail -n1)
-TARGET_IMG=$IMAGE_DIR/$TARGET_NAME.img
-TARGET_IMG_SWAP=$IMAGE_DIR/$TARGET_NAME-swap.img
+if [ -f $BASE_IMAGE_DIR/${SOURCE_NAME}*.qcow2 ]; then
+    SOURCE_IMG=$(ls -v1 $BASE_IMAGE_DIR/${SOURCE_NAME}*.qcow2 | tail -n1)
+elif [ -f $BASE_IMAGE_DIR/${SOURCE_NAME}*.img ]; then
+    SOURCE_IMG=$(ls -v1 $BASE_IMAGE_DIR/${SOURCE_NAME}*.img | tail -n1)
+else
+    echo "Source image $BASE_IMAGE_DIR/${SOURCE_NAME}* not found" 1>&2
+    exit 1
+fi
+TARGET_IMG=$IMAGE_DIR/$TARGET_NAME.qcow2
+TARGET_IMG_SWAP=$IMAGE_DIR/$TARGET_NAME-swap.qcow2
 MAC="52:54:00$(echo "$(hostname)$TARGET_NAME" | openssl dgst -md5 -binary | hexdump -ve '/1 ":%02x"' -n 3)"
 TARGET_HOSTNAME=$TARGET_HOSTNAME
 if [ -z "$TARGET_HOSTNAME" ]; then
   TARGET_HOSTNAME="$PREFIX$TARGET_NAME$DOMAIN"
-fi
-
-if [ ! -f "$SOURCE_IMG" ]; then
-  echo "Base image $SOURCE_IMG not found!"
-  exit 1
 fi
 
 if [ -f "$TARGET_IMG" ]; then
@@ -289,9 +291,9 @@ fi
 # -- Swap Creation --------------
 
 if [ $SWAP -gt 0 ]; then
-  qemu-img create -f raw $TARGET_IMG_SWAP ${SWAP}M
+  qemu-img create -f qcow2 $TARGET_IMG_SWAP ${SWAP}M
   mkswap -f $TARGET_IMG_SWAP
-  DISK_SWAP="--disk $TARGET_IMG_SWAP,device=disk,bus=virtio,format=raw"
+  DISK_SWAP="--disk $TARGET_IMG_SWAP,device=disk,bus=virtio,format=qcow2"
 else
   DISK_SWAP=""
 fi


### PR DESCRIPTION
Please provide feedback on if this is desired or not. If so, I'll do some actual test :-)

Reason for this is when I want to install the environment on some other host, `*.qcow2` images are almost 100 times smaller thank our `*.img` base images so it is possible to copy them over.