### PR TITLE
Fix static IP on rhel8

### DIFF
--- a/prepare-image.pl
+++ b/prepare-image.pl
@@ -60,14 +60,17 @@ if ($distro eq "debian" || $distro eq "ubuntu") {
 }
 elsif ($distro =~ m/^(fedora|rhel|redhat-based|centos|scientificlinux)$/) {
   print "Setting up for Fedora / RHEL\n";
-  $file = "/etc/sysconfig/network-scripts/ifcfg-eth0";
-  $file =  $g->exists ($file) ? $file : "/etc/sysconfig/network-scripts/ifcfg-ens3";
+  my $device = "eth0";
+  $file = "/etc/sysconfig/network-scripts/ifcfg-$device";
+  if (!$g->exists ($file)) {
+    $device = "ens3";
+    $file =  "/etc/sysconfig/network-scripts/ifcfg-$device";
+  }
   if ($ENV{STATIC_IPADDR}) {
     print "Setting static network configuration\n";
-    $content = "DEVICE=eth0\n";
+    $content = "DEVICE=$device\n";
     $content .= "ONBOOT=yes\n";
     $content .= "BOOTPROTO=static\n";
-    $content .= "NM_CONTROLLED=no\n";
     $content .= "HWADDR=$ENV{MAC}\n";
     $content .= "IPADDR=$ENV{STATIC_IPADDR}\n";
     $content .= "NETMASK=$ENV{STATIC_NETMASK}\n";


### PR DESCRIPTION
Fix static IP on rhel8
- remove NM_CONTROLLED=no (prevents VM to have NIC up running on rhel8)
- fix mismatch ens3 script -> eth0 device (nice to have)